### PR TITLE
Remove need for tslib at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ The package is available on npm as [@shutterstock/p-map-iterable](https://www.np
 ## Importing
 
 ```typescript
-import { IterableMapper, IterableQueueMapper, IterableQueueMapperSimple } from '@shutterstock/p-map-iterable';
+import {
+  IterableMapper,
+  IterableQueueMapper,
+  IterableQueueMapperSimple } from '@shutterstock/p-map-iterable';
 ```
 
 ## API Documentation

--- a/examples/iterable-queue-mapper.ts
+++ b/examples/iterable-queue-mapper.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { IterableQueueMapper } from '@shutterstock/p-map-iterable';
-import AggregateError from 'aggregate-error';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const AggregateError = require('aggregate-error');
 import { promisify } from 'util';
 const sleep = promisify(setTimeout);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shutterstock/p-map-iterable",
   "version": "0.0.0",
-  "description": "Async iterable that maps an async iterable input with backpressure.",
+  "description": "Set of classes that allow you to call mappers with controlled concurrency on iterables or on queues",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "publishConfig": {
@@ -11,10 +11,15 @@
   "keywords": [
     "p-map",
     "p-map-iterable",
+    "blocking-queue",
+    "iterable-queue",
+    "mapping",
     "iterable",
+    "queue",
     "async",
     "promise",
-    "backpressure",
+    "back-pressure",
+    "flow-control",
     "AsyncIterable",
     "AsyncIterator"
   ],

--- a/src/iterable-mapper.ts
+++ b/src/iterable-mapper.ts
@@ -1,7 +1,8 @@
 //
 // 2021-08-25 - Initially based on: https://raw.githubusercontent.com/sindresorhus/p-map/main/index.js
 //
-import AggregateError from 'aggregate-error';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const AggregateError = require('aggregate-error');
 import { IterableQueue } from './iterable-queue';
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,9 +15,10 @@
     "sourceMap": true,
     "resolveJsonModule": true,
 
-    "importHelpers": true,
+    "importHelpers": false,
+    "noEmitHelpers": true,
     "composite": true,
-    "target": "es2016",
+    "target": "es2018",
     "module": "commonjs",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
- Remove dependency on `tslib` at runtime
  - Change 1 import to not need import helpers
  - Change target ECMAScript version from es2016 to es2018 (fully supported by Node 16)