### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-`@shutterstock/p-map-iterable` provides several classes that allow processing results of `p-map`-style mapper functions by iterating the results as they are completed, with back pressure to limit the number of items that are processed ahead of the consumer.
+`@shutterstock/p-map-iterable` provides several classes that allow processing results of `p-map`-style mapper functions by iterating the results as they are completed, with backpressure to limit the number of items that are processed ahead of the consumer.
 
 A common use case for `@shutterstock/p-map-iterable` is as a "prefetcher" that will fetch, for example, AWS S3 files in an AWS Lambda function. By prefetching large files the consumer is able to use 100% of the paid-for Lambda CPU time for the JS thread, rather than waiting idle while the next file is fetched. The backpressure (set by `maxUnread`) prevents the prefetcher from consuming unlimited memory or disk space by racing ahead of the consumer.
 
@@ -117,7 +117,7 @@ These diagrams illustrate the differences in operation betweeen `p-map`, `p-queu
   - User supplied sync or async mapper function
   - Exposes an async iterable interface for consuming mapped items
   - Allows a maximum queue depth of mapped items - if the consumer stops consuming, the queue will fill up, at which point the mapper will stop being invoked until an item is consumed from the queue
-  - This allows mapping with back pressure so that the mapper does not consume unlimited resources (e.g. memory, disk, network, event loop time) by racing ahead of the consumer
+  - This allows mapping with backpressure so that the mapper does not consume unlimited resources (e.g. memory, disk, network, event loop time) by racing ahead of the consumer
 - [IterableQueueMapper](https://tech.shutterstock.com/p-map-iterable/classes/IterableQueueMapper.html)
   - Wraps `IterableMapper`
   - Adds items to the queue via the `enqueue` method
@@ -142,7 +142,7 @@ These diagrams illustrate the differences in operation betweeen `p-map`, `p-queu
 
 See [p-map](https://github.com/sindresorhus/p-map) docs for a good start in understanding what this does.
 
-The key difference between `IterableMapper` and `pMap` are that `IterableMapper` does not return when the entire mapping is done, rather it exposes an iterable that the caller loops through. This enables results to be processed while the mapping is still happening, while optionally allowing for back pressure to slow or stop the mapping if the caller is not consuming items fast enough. Common use cases include `prefetching` items from a remote service - the next set of requests are dispatched asyncronously while the current responses are processed and the prefetch requests will pause when the unread queue fills up.
+The key difference between `IterableMapper` and `pMap` are that `IterableMapper` does not return when the entire mapping is done, rather it exposes an iterable that the caller loops through. This enables results to be processed while the mapping is still happening, while optionally allowing for backpressure to slow or stop the mapping if the caller is not consuming items fast enough. Common use cases include `prefetching` items from a remote service - the next set of requests are dispatched asyncronously while the current responses are processed and the prefetch requests will pause when the unread queue fills up.
 
 See [examples/iterable-mapper.ts](./examples/iterable-mapper.ts) for an example.
 

--- a/examples/iterable-queue-mapper-simple.ts
+++ b/examples/iterable-queue-mapper-simple.ts
@@ -31,7 +31,7 @@ async function main() {
   let callCount = 0;
 
   // Create an item processor with IterableQueueMapperSimple
-  const prefetcher = new IterableQueueMapperSimple(
+  const backgroundFlusher = new IterableQueueMapperSimple(
     // mapper function
     async (value: number): Promise<void> => {
       const myCallCount = callCount++;
@@ -39,9 +39,7 @@ async function main() {
 
       console.log(`Mapper Call Start ${myCallCount}, Value: ${value}, Total: ${total}`);
 
-      // Simulate fetching an async item with varied delays
-      // await sleep(10 * (callCount % 7));
-      // Wait short random time
+      // Simulate flushing an async item with varied delays
       await sleep(Math.random() * 10000);
 
       if (value % 5 === 0) {
@@ -53,26 +51,27 @@ async function main() {
     { concurrency: 3 },
   );
 
-  // Add items to the queue in the background
+  // Add items to be flushed to the queue in the background
+  // This will pause when the queue is full and resume when there is capacity
   const jobAdder = (async () => {
     for await (const item of iterator) {
       console.log(`Enqueue Start ${item}`);
-      await prefetcher.enqueue(item);
+      await backgroundFlusher.enqueue(item);
       console.log(`Enqueue Done  ${item}`);
     }
   })();
 
   // Wait for the job adder to finish adding the jobs
-  // (it's throughput is constrained by the prefetcher's concurrency)
+  // (it's throughput is constrained by the flushers's concurrency)
   await jobAdder;
 
-  // Wait for the prefetcher to finish processing all items
-  await prefetcher.onIdle();
+  // Wait for the async flusher to finish flushing all items
+  await backgroundFlusher.onIdle();
 
   // Check for errors
-  if (prefetcher.errors.length > 0) {
+  if (backgroundFlusher.errors.length > 0) {
     console.error('Errors:');
-    prefetcher.errors.forEach(({ error, item }) =>
+    backgroundFlusher.errors.forEach(({ error, item }) =>
       console.error(
         `${item} had error: ${(error as Error).message ? (error as Error).message : error}`,
       ),
@@ -80,6 +79,7 @@ async function main() {
   }
 
   console.log(`Total: ${total}`);
+  console.log('Note - It is intended that there are errors in this example');
 }
 
 void main();

--- a/examples/iterable-queue-mapper.ts
+++ b/examples/iterable-queue-mapper.ts
@@ -135,6 +135,7 @@ async function main() {
   await jobAdder;
 
   console.log(`QueuedButUnreadFileSizeGB: ${queuedButUnreadFileSizeGB}`);
+  console.log('Note - It is intended that there are errors in this example');
 }
 
 void main();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shutterstock/p-map-iterable",
   "version": "0.0.0",
-  "description": "Set of classes that allow you to call mappers with controlled concurrency on iterables or on queues",
+  "description": "Set of classes used for async prefetching with backpressure (IterableMapper) and async flushing with backpressure (IterableQueueMapper, IterableQueueMapperSimple)",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "publishConfig": {

--- a/src/iterable-mapper.ts
+++ b/src/iterable-mapper.ts
@@ -127,7 +127,10 @@ type NewElementOrError<NewElement = unknown> = {
  *
  * This reduces iteration time to 520ms by overlapping reads with processing/writing.
  *
- * For maximum throughput, combine with IterableQueueMapperSimple for concurrent writes:
+ * For maximum throughput, make the writes concurrent with
+ * IterableQueueMapper (to iterate results with backpressure when too many unread items) or
+ * IterableQueueMapperSimple (to handle errors at end without custom iteration or backpressure):
+ *
  * ```typescript
  * const source = new SomeSource();
  * const sourceIds = [1, 2,... 1000];
@@ -152,7 +155,9 @@ type NewElementOrError<NewElement = unknown> = {
  * }
  * ```
  *
- * This reduces iteration time to about 20ms by overlapping reads and writes.
+ * This reduces iteration time to about 20ms by overlapping reads and writes with the CPU processing step.
+ * In this contrived (but common) example we would get a 41x improvement in throughput, removing 97.5% of
+ * the time to process each item and fully utilizing the CPU time available in the JS event loop.
  *
  * @category Iterable Input
  */


### PR DESCRIPTION
- Add example code to the jsdocs for `IterableMapper`
- Clarify that `IterableMapper` is best used for prefetchers and can be used for writers when a subsequent pipeline step depends on the write completing
- Update options jsdocs for `IterableMapper`
- Add test that confirms that iteration order is unchanged when `concurrency` is `1`